### PR TITLE
Fix test token generator URL

### DIFF
--- a/test/generateTestToken.ts
+++ b/test/generateTestToken.ts
@@ -13,7 +13,7 @@ console.log('Generated Test Token:', token);
 
 // 테스트 요청 보내기
 async function testGetItems() {
-  const apiUrl = 'http://localhost:4000/items'; // API 엔드포인트 URL
+  const apiUrl = 'http://localhost:4000/space-engineers/item'; // API 엔드포인트 URL
 
   try {
     console.log(`Sending request to ${apiUrl} with token...`);


### PR DESCRIPTION
## Summary
- point token generator test to the /space-engineers/item endpoint
- tests still reference the appropriate endpoints

## Testing
- `npm test`
- `npm run lint` *(fails: 256 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685a29cf8174832c8197395af92317a1