### PR TITLE
Remove invalid e2e script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ $ npm run start:prod
 # unit tests
 $ npm run test
 
-# e2e tests
-$ npm run test:e2e
-
 # test coverage
 $ npm run test:cov
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
     "migration:run": "npx ts-node ./node_modules/typeorm/cli.js migration:run --dataSource src/data-source.ts",
     "migration:revert": "npx ts-node ./node_modules/typeorm/cli.js migration:revert --dataSource src/data-source.ts",
     "migration:generate": "npx ts-node ./node_modules/typeorm/cli.js migration:generate --dataSource src/data-source.ts --name",


### PR DESCRIPTION
## Summary
- remove `test:e2e` script from package.json
- update README so test commands match available scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a29ce95bc832c93509630fcf38830